### PR TITLE
Correct link to Granary

### DIFF
--- a/index-src.html
+++ b/index-src.html
@@ -353,7 +353,7 @@
       <section id="granary">
         <h3>Granary</h3>
         <p>
-          [https://github.com/snarfed/granary/ Granary] synthesizes ActivityStreams [[AS1]], 
+          <a href="https://github.com/snarfed/granary/">Granary</a> synthesizes ActivityStreams [[AS1]], 
           [[microformats2]], and Atom [[RFC4287]] from various input feeds and sources, and 
           as such has some code that can be considered in progress or even a partial 
           implementation of Post Type Discovery:


### PR DESCRIPTION
Was in wiki format; now in HTML format
